### PR TITLE
Makefile: fix firmware asset URL pattern (was SDDC_FX3-&lt;tag&gt;.img, should be SDDC_FX3.img)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ INCDIR := include
 RX888_FW_REPO := ringof/rx888-firmware
 RX888_FW_TAG  := $(strip $(shell cat firmware/VERSION 2>/dev/null))
 RX888_FW_FILE := firmware/SDDC_FX3.img
-RX888_FW_URL  := https://github.com/$(RX888_FW_REPO)/releases/download/$(RX888_FW_TAG)/SDDC_FX3-$(RX888_FW_TAG).img
+RX888_FW_URL  := https://github.com/$(RX888_FW_REPO)/releases/download/$(RX888_FW_TAG)/SDDC_FX3.img
 
 # librx888 sources
 LIBRX_OBJS := $(SRCDIR)/librx888.o $(SRCDIR)/ezusb.o
@@ -165,7 +165,7 @@ firmware-latest:
 	@tag=$$(curl -fsSL https://api.github.com/repos/$(RX888_FW_REPO)/releases/latest | jq -r .tag_name); \
 	  [ -n "$$tag" ] && [ "$$tag" != "null" ] || { echo "could not resolve latest tag"; exit 1; }; \
 	  echo "Bumping firmware to $$tag"; \
-	  url="https://github.com/$(RX888_FW_REPO)/releases/download/$$tag/SDDC_FX3-$$tag.img"; \
+	  url="https://github.com/$(RX888_FW_REPO)/releases/download/$$tag/SDDC_FX3.img"; \
 	  curl -fL -o firmware/SDDC_FX3.img.tmp "$$url"; \
 	  echo "$$tag" > firmware/VERSION; \
 	  ( cd firmware && sha256sum SDDC_FX3.img.tmp \


### PR DESCRIPTION
## Symptom

```
$ make firmware-latest
Bumping firmware to v0.1.0
curl: (22) The requested URL returned error: 404

$ make firmware
Fetching firmware v0.1.0 from ringof/rx888-firmware...
curl: (22) The requested URL returned error: 404
```

## Cause

Both `firmware` and `firmware-latest` targets build the asset URL as `SDDC_FX3-<tag>.img`, but rx888-firmware releases name the asset just `SDDC_FX3.img` (no version suffix).

Confirmed against the v0.1.0 release:

| URL | HTTP |
|---|---|
| `.../releases/download/v0.1.0/SDDC_FX3.img` | 200 |
| `.../releases/download/v0.1.0/SDDC_FX3-v0.1.0.img` | 404 |
| `.../releases/download/v0.1.0/SDDC_FX3-0.1.0.img` | 404 |

## Fix

Drop the `-<tag>` suffix from both URL constructions.

## Note (out of scope)

`firmware/VERSION` on main is pinned to `v0.1.0-rc1`, which doesn't have a downloadable `SDDC_FX3.img` asset attached. After this fix, `make firmware-latest` will resolve the actual latest tag (v0.1.0) and self-heal both `firmware/VERSION` and `firmware/SHA256SUMS`. Not bumping VERSION in this PR — keeping the diff narrow to the URL fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXg8aqeEaAGF9BadH5SyuZ)_