### PR TITLE
fx3_cmd: stream-safe --no-claim set + --force for unsafe commands / full debug during a stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-# Compiled binaries
-rx888_stream
-rx888_dsp
-iqrecord
-fx3_cmd
+# Compiled binaries (anchored to repo root so the rules don't also match the
+# src/fx3_cmd/ source directory)
+/rx888_stream
+/rx888_dsp
+/iqrecord
+/fx3_cmd
 
 # Library + pkg-config build outputs
 librx888.so

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ endpoint (EP0) to probe the device, poke registers (GPIO, ADC clock,
 attenuator, VGA, I2C), read firmware `GETSTATS` counters, and recover a wedged
 device (`reset` / `usbreset` / `reload`). It is for bring-up and debugging, not
 the data path — it links libusb directly and is independent of `librx888`. Its
-read-only `--no-claim` mode can even query the device *while a streamer is
-running*. See [`doc/fx3_cmd.md`](doc/fx3_cmd.md).
+`--no-claim` mode can query and live-tune the device *while a streamer is
+running* (and, with `--force`, run the full debug console). See
+[`doc/fx3_cmd.md`](doc/fx3_cmd.md).
 
 ---
 
@@ -207,7 +208,9 @@ make fx3_cmd                                   # build (needs libusb-1.0-0-dev)
 ./fx3_cmd usbreset                             # host-side USB port reset
 ./fx3_cmd -F SDDC_FX3.img reload               # reset → re-upload → verify
 ./fx3_cmd debug                                # interactive console (! for local cmds)
-./fx3_cmd --no-claim stats                     # read-only; safe while a streamer runs
+./fx3_cmd --no-claim stats                     # stream-safe; query while a streamer runs
+./fx3_cmd --no-claim att 20                    # stream-safe; live attenuator tuning
+./fx3_cmd --no-claim --force debug             # full console during a stream (knowingly disruptive)
 ```
 
 `load`/`reload`/`-F` upload firmware via `rx888_stream`, found alongside the
@@ -216,9 +219,13 @@ list.
 
 `fx3_cmd` claims the USB interface exclusively, so its normal commands **cannot
 run while a streamer (`rx888_stream`, ka9q-radio, …) holds the device** — stop
-the streamer first. The exception is the read-only `--no-claim` mode (`test`,
-`stats`, `stats_pll`, `stack_check`), which peeks at EP0 without disturbing an
-active stream. See [`doc/fx3_cmd.md`](doc/fx3_cmd.md#running-alongside-a-streamer-exclusive-access).
+the streamer first. With `--no-claim` it opens without claiming and runs the
+**stream-safe** EP0 commands (`test`, `stats`, `stats_pll`, `stack_check`, plus
+live `att`/`vga`/`wdg_max` tuning) alongside an active stream; add `--force` to
+also run the stream-**unsafe** commands and the full `debug` console, accepting
+that they may glitch/stop/reset the device. The firmware concurrency contract is
+[`rx888-firmware#170`](https://github.com/ringof/rx888-firmware/issues/170); see
+[`doc/fx3_cmd.md`](doc/fx3_cmd.md#running-alongside-a-streamer-exclusive-access).
 
 `fx3_cmd` shares the wire-protocol constants in `include/rx888.h` with
 `librx888` — there is no separate protocol header. The GPIO bit map in

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ make fx3_cmd                                   # build (needs libusb-1.0-0-dev)
 ./fx3_cmd debug                                # interactive console (! for local cmds)
 ./fx3_cmd --no-claim stats                     # stream-safe; query while a streamer runs
 ./fx3_cmd --no-claim att 20                    # stream-safe; live attenuator tuning
-./fx3_cmd --no-claim --force debug             # full console during a stream (knowingly disruptive)
+./fx3_cmd --force debug                        # full console during a stream (knowingly disruptive)
 ```
 
 `load`/`reload`/`-F` upload firmware via `rx888_stream`, found alongside the
@@ -221,9 +221,10 @@ list.
 run while a streamer (`rx888_stream`, ka9q-radio, …) holds the device** — stop
 the streamer first. With `--no-claim` it opens without claiming and runs the
 **stream-safe** EP0 commands (`test`, `stats`, `stats_pll`, `stack_check`, plus
-live `att`/`vga`/`wdg_max` tuning) alongside an active stream; add `--force` to
-also run the stream-**unsafe** commands and the full `debug` console, accepting
-that they may glitch/stop/reset the device. The firmware concurrency contract is
+live `att`/`vga`/`wdg_max` tuning) alongside an active stream; `--force` (which
+implies `--no-claim`) also runs the stream-**unsafe** commands and the full
+`debug` console, accepting that they may glitch/stop/reset the device. The
+firmware concurrency contract is
 [`rx888-firmware#170`](https://github.com/ringof/rx888-firmware/issues/170); see
 [`doc/fx3_cmd.md`](doc/fx3_cmd.md#running-alongside-a-streamer-exclusive-access).
 

--- a/doc/fx3_cmd.md
+++ b/doc/fx3_cmd.md
@@ -43,7 +43,7 @@ Built at the repo root next to `rx888_stream` (and installed into the same
 | `vga <0-255>` | `SETARGFX3`/`AD8370_VGA` | AD8370 VGA gain code |
 | `wdg_max <0-255>` | `SETARGFX3`/`WDG_MAX_RECOV` | Watchdog max recovery count (0 = unlimited) |
 | `start` / `stop` | `STARTFX3` / `STOPFX3` | Start / stop the GPIF streaming engine |
-| `i2cr <addr> <reg> <len>` | `I2CRFX3` | I2C read (hex) |
+| `i2cr <addr> <reg> <len>` | `I2CRFX3` | I2C read (hex). On failure, enables firmware debug and drains the I2C NAK reason (`ec=N`). |
 | `i2cw <addr> <reg> <byte>...` | `I2CWFX3` | I2C write (hex) |
 | `stats` | `GETSTATS` | Dump the firmware diagnostic counters |
 | `stats_pll` | `GETSTATS` | Verify the Si5351 PLL is locked |

--- a/doc/fx3_cmd.md
+++ b/doc/fx3_cmd.md
@@ -100,16 +100,49 @@ is running — but they are destructive**:
 
 These exist to recover a *wedged* device, not to coexist with a healthy stream.
 
+### Why this works — the Linux USB claiming model
+
+A common assumption is that opening a USB device is exclusive. On Linux it
+isn't. A device is a usbfs node (`/dev/bus/usb/BBB/DDD`) with three independent
+access layers, and **only the middle one is exclusive**:
+
+1. **Open** (`libusb_open`) — *not* exclusive. Multiple processes can hold the
+   same device open at once; opening claims nothing.
+2. **Claim an interface** (`libusb_claim_interface` → `USBDEVFS_CLAIMINTERFACE`)
+   — exclusive, one owner per interface. A second claim returns
+   `LIBUSB_ERROR_BUSY` (the `Resource busy` above).
+3. **Endpoint I/O** — bulk/interrupt/isochronous transfers require the claim on
+   the interface that owns the endpoint. Streaming is bulk-IN on EP1, hence the
+   claim.
+
+**Endpoint 0 sits outside all of this and cannot be claimed.** EP0 is the
+device's default *control* pipe, defined by the device descriptor — it is not
+listed in any interface descriptor, so there is no ioctl to take it. It is
+shared by every open handle, always. When the streamer claims interface 0 it
+gets interface 0's bulk endpoint exclusively; **EP0 was never — and cannot be —
+exclusively held by anyone.**
+
+The RX888's entire command set is vendor control transfers addressed to the
+*device* (recipient = device), which usbfs permits without consulting any
+interface claim. So `--no-claim` just opens the device (allowed), skips the
+claim, and pokes EP0 — concurrently with the streamer's bulk transfers on EP1,
+which it never touches. (Everyday proof that EP0 is shared: `lsusb -v` reads
+descriptors over EP0 from devices that already have drivers bound and interfaces
+claimed.)
+
+This is a property of *every* USB device, not just the RX888 — EP0 is mandatory
+and is how enumeration happens before any driver or claim exists. What is
+RX888-specific is only that its firmware (a) implements useful vendor commands
+on EP0 and (b) services them on a thread separate from the GPIF/DMA stream, so
+concurrent EP0 traffic doesn't disturb streaming — see the firmware concurrency
+contract, [`rx888-firmware#170`](https://github.com/ringof/rx888-firmware/issues/170).
+
 ### `--no-claim` — using stream-safe commands during a stream
 
 `--no-claim` opens the device *without* claiming interface 0 or touching the
-bulk endpoint. Vendor control transfers go to endpoint 0, which is not owned by
-any interface and is serviced on a **separate firmware thread** from the
-GPIF→DMA streaming path, so the firmware handles them even while another process
-streams with interface 0 claimed. (See the firmware concurrency contract,
-[`rx888-firmware#170`](https://github.com/ringof/rx888-firmware/issues/170).)
-
-Per that contract, `--no-claim` allows the **stream-safe** EP0 commands:
+bulk endpoint, so its EP0 vendor commands run while another process streams with
+interface 0 claimed (see *Why this works* above). Per the firmware contract,
+`--no-claim` allows the **stream-safe** EP0 commands:
 
 | Command(s) | Vendor request | Why it's safe |
 |---|---|---|

--- a/doc/fx3_cmd.md
+++ b/doc/fx3_cmd.md
@@ -8,7 +8,7 @@ device. It is **not** part of the streaming data path; `rx888_stream` /
 `librx888` own that.
 
 ```
-fx3_cmd [-F firmware.img] [--no-claim] <command> [args...]
+fx3_cmd [-F firmware.img] [--no-claim [--force]] <command> [args...]
 ```
 
 Unlike `rx888_stream`, `fx3_cmd` does **not** link `librx888`. It talks to
@@ -100,25 +100,57 @@ is running — but they are destructive**:
 
 These exist to recover a *wedged* device, not to coexist with a healthy stream.
 
-### `--no-claim` — read-only peeking during a stream
+### `--no-claim` — using stream-safe commands during a stream
 
-For the read-only, EP0-only commands — **`test`, `stats`, `stats_pll`,
-`stack_check`** — pass `--no-claim` to open the device *without* claiming
-interface 0 or touching the bulk endpoint. Vendor control transfers go to
-endpoint 0, which is not owned by any interface, so the firmware services them
-even while another process streams with interface 0 claimed:
+`--no-claim` opens the device *without* claiming interface 0 or touching the
+bulk endpoint. Vendor control transfers go to endpoint 0, which is not owned by
+any interface and is serviced on a **separate firmware thread** from the
+GPIF→DMA streaming path, so the firmware handles them even while another process
+streams with interface 0 claimed. (See the firmware concurrency contract,
+[`rx888-firmware#170`](https://github.com/ringof/rx888-firmware/issues/170).)
+
+Per that contract, `--no-claim` allows the **stream-safe** EP0 commands:
+
+| Command(s) | Vendor request | Why it's safe |
+|---|---|---|
+| `test` | `TESTFX3` | read-only device info |
+| `stats`, `stats_pll` | `GETSTATS` | reads counters (non-coherent snapshot) |
+| `stack_check` | `TESTFX3` + `READINFODEBUG` | debug-log read, negligible interrupt |
+| `att`, `vga`, `wdg_max` | `SETARGFX3` | live gain/attenuator tuning; no stream impact |
 
 ```sh
-# ka9q-radio (or rx888_stream) is streaming; peek at firmware counters:
+# ka9q-radio (or rx888_stream) is streaming; peek and tune live:
 fx3_cmd --no-claim stats
 fx3_cmd --no-claim stats_pll
-fx3_cmd --no-claim test
+fx3_cmd --no-claim att 20        # adjust the attenuator without stopping the stream
 ```
 
-`--no-claim` is rejected (exit `2`) for any command that writes, recovers, or
-uploads — those need the claim or would perturb the stream. Note the reads are a
-non-coherent snapshot taken while the device is busy; treat them as monitoring,
-not ground truth.
+Reads are a non-coherent snapshot taken while the device is busy — treat them as
+monitoring, not ground truth.
+
+### `--force` — stream-unsafe commands and the full debug console
+
+The remaining commands are **stream-unsafe**: per the firmware contract,
+`GPIOFX3` (`gpio`), `STARTADC` (`adc`), `STARTFX3`/`STOPFX3` (`start`/`stop`,
+and `stats_shdn` which issues them), and `RESETFX3` (`reset`) stop or disrupt
+the GPIF/DMA stream. Under `--no-claim` they are rejected (exit `2`) unless you
+add **`--force`**:
+
+```sh
+fx3_cmd --no-claim gpio 0x20            # error: not stream-safe; re-run with --force
+fx3_cmd --no-claim --force gpio 0x20    # runs it; warns that it may disrupt the stream
+fx3_cmd --no-claim --force debug        # full interactive console during a stream
+```
+
+`--force` enables the **full `debug` console** (including its `!stop` / `!reset`
+/ `!gpio` / `!adc` local commands) alongside a running stream. Everything still
+goes over EP0 — no interface claim — so the firmware will not crash; the
+consequence you are accepting is that these commands **glitch, stop, or reset
+the device** out from under the streamer. `--force` only has meaning with
+`--no-claim`.
+
+`load`, `usbreset`, and `reload` are not part of `--no-claim` (they have their
+own non-claiming or recovery paths — run them without `--no-claim`).
 
 ---
 

--- a/doc/fx3_cmd.md
+++ b/doc/fx3_cmd.md
@@ -8,7 +8,7 @@ device. It is **not** part of the streaming data path; `rx888_stream` /
 `librx888` own that.
 
 ```
-fx3_cmd [-F firmware.img] [--no-claim [--force]] <command> [args...]
+fx3_cmd [-F firmware.img] [--no-claim | --force] <command> [args...]
 ```
 
 Unlike `rx888_stream`, `fx3_cmd` does **not** link `librx888`. It talks to
@@ -179,8 +179,8 @@ left alone.
 
 - `PASS <command> [details]` on success, exit `0`.
 - `FAIL <command> <reason>` on failure, exit `1`.
-- Usage error (unknown command, wrong argument count, or `--no-claim` on a
-  non-allowlisted command) exits `2`.
+- Usage error (unknown command, wrong argument count, or a stream-unsafe
+  command under `--no-claim` without `--force`) exits `2`.
 
 The command name and argument count are validated **before** the device is
 opened, so a typo or wrong arity is always a `2` — independent of whether a
@@ -226,10 +226,12 @@ runs `tests/hw_fx3_cmd.sh`, which exercises the real vendor commands and the
   `stats_shdn` graceful-degradation path on legacy 26-byte `GETSTATS` firmware.
 - **exclusive-access guard:** a normal command is refused (`Resource busy`,
   exit 1) while `rx888_stream` holds interface 0.
-- **`--no-claim` concurrency:** read-only commands succeed alongside the
-  stream, `GETSTATS` `dma_count` advances between two snapshots while
-  `boot_count` stays put, and `--no-claim stack_check` (the debug/EP0 channel)
-  does not stall the stream — early evidence for the observe-only-debug
+- **`--no-claim` concurrency:** stream-safe commands succeed alongside the
+  stream — including live `att`/`vga` tuning — with `GETSTATS` `dma_count`
+  advancing between snapshots while `boot_count` stays put; a stream-unsafe
+  command (`gpio`) is refused without `--force`; and `--no-claim stack_check`
+  (the debug/EP0 channel) does not stall the stream — early evidence for the
+  observe-only-debug
   question in issue #27.
 
 It is non-destructive (leaves the device loaded and idle); `usbreset`/`reload`

--- a/doc/fx3_cmd.md
+++ b/doc/fx3_cmd.md
@@ -134,23 +134,24 @@ The remaining commands are **stream-unsafe**: per the firmware contract,
 `GPIOFX3` (`gpio`), `STARTADC` (`adc`), `STARTFX3`/`STOPFX3` (`start`/`stop`,
 and `stats_shdn` which issues them), and `RESETFX3` (`reset`) stop or disrupt
 the GPIF/DMA stream. Under `--no-claim` they are rejected (exit `2`) unless you
-add **`--force`**:
+use **`--force`**, which **implies `--no-claim`** (you don't need both — you
+never claim the interface to disrupt a stream; the disruption is via EP0 vendor
+commands either way):
 
 ```sh
-fx3_cmd --no-claim gpio 0x20            # error: not stream-safe; re-run with --force
-fx3_cmd --no-claim --force gpio 0x20    # runs it; warns that it may disrupt the stream
-fx3_cmd --no-claim --force debug        # full interactive console during a stream
+fx3_cmd --no-claim gpio 0x20      # error: not stream-safe; re-run with --force
+fx3_cmd --force gpio 0x20         # runs it; warns that it may disrupt the stream
+fx3_cmd --force debug             # full interactive console during a stream
 ```
 
 `--force` enables the **full `debug` console** (including its `!stop` / `!reset`
 / `!gpio` / `!adc` local commands) alongside a running stream. Everything still
 goes over EP0 — no interface claim — so the firmware will not crash; the
 consequence you are accepting is that these commands **glitch, stop, or reset
-the device** out from under the streamer. `--force` only has meaning with
-`--no-claim`.
+the device** out from under the streamer.
 
-`load`, `usbreset`, and `reload` are not part of `--no-claim` (they have their
-own non-claiming or recovery paths — run them without `--no-claim`).
+`load`, `usbreset`, and `reload` are not part of `--no-claim`/`--force` (they
+have their own non-claiming or recovery paths — run them on their own).
 
 ---
 

--- a/src/fx3_cmd/fx3_cmd.c
+++ b/src/fx3_cmd/fx3_cmd.c
@@ -285,16 +285,22 @@ static unsigned long parse_num(const char *s)
 static void usage(const char *prog)
 {
     fprintf(stderr,
-        "Usage: %s [-F firmware.img] [--no-claim] <command> [args...]\n"
+        "Usage: %s [-F firmware.img] [--no-claim [--force]] <command> [args...]\n"
         "\n"
         "Options:\n"
         "  -F, --firmware <path>        Upload firmware first if device is in\n"
         "                               bootloader mode (PID 0x00F3)\n"
         "      --no-claim               Open without claiming interface 0 or\n"
-        "                               touching the bulk endpoint. Read-only EP0\n"
-        "                               commands only (test/stats/stats_pll/\n"
-        "                               stack_check). Safe to run while another\n"
-        "                               process (e.g. ka9q-radio) is streaming.\n"
+        "                               touching the bulk endpoint. Allows the\n"
+        "                               stream-safe EP0 commands (test, stats,\n"
+        "                               stats_pll, stack_check, att, vga, wdg_max)\n"
+        "                               to run while another process (e.g.\n"
+        "                               ka9q-radio) is streaming. (See firmware\n"
+        "                               contract rx888-firmware#170.)\n"
+        "      --force                  With --no-claim, also allow the stream-\n"
+        "                               UNSAFE commands and the full debug console\n"
+        "                               during a stream. These can glitch, stop, or\n"
+        "                               reset the device — use knowingly.\n"
         "\n"
         "Commands:\n"
         "  load <firmware.img>          Upload firmware and exit\n"
@@ -325,38 +331,49 @@ static void usage(const char *prog)
 }
 
 /* Command table: name + allowed count of positional arguments (tokens after
- * the command word; -F/--firmware and --no-claim are stripped first).
+ * the command word; -F/--firmware, --no-claim and --force are stripped first).
  * max_args < 0 means unbounded (i2cw takes a variable number of data bytes).
  * Used to validate the command line *before* opening the device, so a typo or
  * wrong arity is a usage error (exit 2) regardless of whether a device is
- * attached or a streamer holds the interface. */
+ * attached or a streamer holds the interface.
+ *
+ * `nc` is the command's behaviour under --no-claim while a stream may be
+ * running, per the firmware concurrency contract (ringof/rx888-firmware#170):
+ *   NC_SAFE  — stream-safe EP0 command; allowed under --no-claim.
+ *   NC_FORCE — stream-unsafe (stops/disrupts the GPIF/DMA stream); allowed
+ *              under --no-claim only with --force.
+ *   NC_NO    — not a stream-coexistence command (load/usbreset/reload have
+ *              their own non-claiming or recovery paths). */
+enum nc_class { NC_NO = 0, NC_SAFE = 1, NC_FORCE = 2 };
+
 struct cmd_spec {
     const char *name;
     int min_args;
     int max_args;   /* < 0 = unbounded */
+    int nc;         /* enum nc_class */
 };
 
 static const struct cmd_spec COMMANDS[] = {
-    {"load",        0,  1},
-    {"reload",      0,  1},
-    {"test",        0,  0},
-    {"gpio",        1,  1},
-    {"adc",         1,  1},
-    {"att",         1,  1},
-    {"vga",         1,  1},
-    {"wdg_max",     1,  1},
-    {"start",       0,  0},
-    {"stop",        0,  0},
-    {"i2cr",        3,  3},
-    {"i2cw",        3, -1},
-    {"reset",       0,  0},
-    {"usbreset",    0,  0},
-    {"debug",       0,  0},
-    {"raw",         1,  1},
-    {"stats",       0,  0},
-    {"stats_pll",   0,  0},
-    {"stats_shdn",  0,  0},
-    {"stack_check", 0,  0},
+    {"load",        0,  1, NC_NO},
+    {"reload",      0,  1, NC_NO},
+    {"test",        0,  0, NC_SAFE},
+    {"gpio",        1,  1, NC_FORCE},   /* GPIOFX3: clobbers stream pins */
+    {"adc",         1,  1, NC_FORCE},   /* STARTADC: resets GPIF/DMA */
+    {"att",         1,  1, NC_SAFE},    /* SETARGFX3: live gain tuning */
+    {"vga",         1,  1, NC_SAFE},    /* SETARGFX3: live gain tuning */
+    {"wdg_max",     1,  1, NC_SAFE},    /* SETARGFX3 */
+    {"start",       0,  0, NC_FORCE},   /* STARTFX3 */
+    {"stop",        0,  0, NC_FORCE},   /* STOPFX3 */
+    {"i2cr",        3,  3, NC_FORCE},   /* I2C: unclassified -> caution */
+    {"i2cw",        3, -1, NC_FORCE},
+    {"reset",       0,  0, NC_FORCE},   /* RESETFX3: reboots device */
+    {"usbreset",    0,  0, NC_NO},
+    {"debug",       0,  0, NC_FORCE},   /* console can issue unsafe commands */
+    {"raw",         1,  1, NC_FORCE},
+    {"stats",       0,  0, NC_SAFE},    /* GETSTATS */
+    {"stats_pll",   0,  0, NC_SAFE},    /* GETSTATS */
+    {"stats_shdn",  0,  0, NC_FORCE},   /* issues STARTADC/STARTFX3/STOPFX3 */
+    {"stack_check", 0,  0, NC_SAFE},    /* TESTFX3 + READINFODEBUG */
 };
 
 static const struct cmd_spec *command_lookup(const char *name)
@@ -369,10 +386,12 @@ static const struct cmd_spec *command_lookup(const char *name)
 
 int main(int argc, char **argv)
 {
-    /* ---- Parse --no-claim flag (strip from argv) ---- */
+    /* ---- Parse --no-claim / --force flags (strip from argv) ---- */
+    int force = 0;
     for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "--no-claim") == 0) {
-            g_no_claim = 1;
+        if (strcmp(argv[i], "--no-claim") == 0 || strcmp(argv[i], "--force") == 0) {
+            if (strcmp(argv[i], "--force") == 0) force = 1;
+            else                                 g_no_claim = 1;
             int remaining = argc - i - 1;
             memmove(&argv[i], &argv[i + 1], remaining * sizeof(char *));
             argc -= 1;
@@ -436,18 +455,32 @@ int main(int argc, char **argv)
         return 2;
     }
 
-    /* --no-claim is only meaningful for the read-only EP0 commands.  Writes,
-     * recovery, firmware upload, and the debug console all need a claimed
-     * interface (or would perturb a running stream), so reject them up front
-     * rather than silently producing a confusing libusb error. */
-    if (g_no_claim &&
-        strcmp(cmd, "test")       != 0 &&
-        strcmp(cmd, "stats")      != 0 &&
-        strcmp(cmd, "stats_pll")  != 0 &&
-        strcmp(cmd, "stack_check") != 0) {
-        fprintf(stderr, "error: --no-claim is only valid for read-only commands "
-                        "(test, stats, stats_pll, stack_check)\n");
+    /* --no-claim opens the device without claiming interface 0, so EP0 vendor
+     * commands run alongside a stream (per the firmware concurrency contract,
+     * ringof/rx888-firmware#170).  Gate which commands are allowed there using
+     * the per-command stream-safety class; --force opts in to the stream-unsafe
+     * ones (and the full debug console), accepting that they may stop/disrupt
+     * the stream.  --force only makes sense together with --no-claim. */
+    if (force && !g_no_claim) {
+        fprintf(stderr, "error: --force only applies to --no-claim\n");
         return 2;
+    }
+    if (g_no_claim) {
+        if (spec->nc == NC_NO) {
+            fprintf(stderr, "error: '%s' cannot run under --no-claim; "
+                            "run it without --no-claim\n", cmd);
+            return 2;
+        }
+        if (spec->nc == NC_FORCE && !force) {
+            fprintf(stderr,
+                "error: '%s' is not stream-safe (per rx888-firmware#170) and can\n"
+                "       disrupt or stop a running stream. Re-run with\n"
+                "       '--no-claim --force' to do it anyway.\n", cmd);
+            return 2;
+        }
+        if (spec->nc == NC_FORCE && force)
+            fprintf(stderr, "warning: '%s' may disrupt or stop an active stream "
+                            "(--force)\n", cmd);
     }
 
     libusb_context *ctx = NULL;

--- a/src/fx3_cmd/fx3_cmd.c
+++ b/src/fx3_cmd/fx3_cmd.c
@@ -285,7 +285,7 @@ static unsigned long parse_num(const char *s)
 static void usage(const char *prog)
 {
     fprintf(stderr,
-        "Usage: %s [-F firmware.img] [--no-claim [--force]] <command> [args...]\n"
+        "Usage: %s [-F firmware.img] [--no-claim | --force] <command> [args...]\n"
         "\n"
         "Options:\n"
         "  -F, --firmware <path>        Upload firmware first if device is in\n"
@@ -297,10 +297,10 @@ static void usage(const char *prog)
         "                               to run while another process (e.g.\n"
         "                               ka9q-radio) is streaming. (See firmware\n"
         "                               contract rx888-firmware#170.)\n"
-        "      --force                  With --no-claim, also allow the stream-\n"
-        "                               UNSAFE commands and the full debug console\n"
-        "                               during a stream. These can glitch, stop, or\n"
-        "                               reset the device — use knowingly.\n"
+        "      --force                  Implies --no-claim, and ALSO allows the\n"
+        "                               stream-UNSAFE commands and the full debug\n"
+        "                               console during a stream. These can glitch,\n"
+        "                               stop, or reset the device — use knowingly.\n"
         "\n"
         "Commands:\n"
         "  load <firmware.img>          Upload firmware and exit\n"
@@ -386,18 +386,26 @@ static const struct cmd_spec *command_lookup(const char *name)
 
 int main(int argc, char **argv)
 {
-    /* ---- Parse --no-claim / --force flags (strip from argv) ---- */
+    /* ---- Parse --no-claim / --force flags (strip from argv) ----
+     * --force implies --no-claim: you never open the interface to disrupt a
+     * stream — the disruption is via EP0 vendor commands either way — so there
+     * is no reason to require both.  --no-claim alone = stream-safe commands;
+     * --force = also the stream-unsafe ones (and the full debug console). */
     int force = 0;
     for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "--no-claim") == 0 || strcmp(argv[i], "--force") == 0) {
-            if (strcmp(argv[i], "--force") == 0) force = 1;
-            else                                 g_no_claim = 1;
-            int remaining = argc - i - 1;
-            memmove(&argv[i], &argv[i + 1], remaining * sizeof(char *));
-            argc -= 1;
-            argv[argc] = NULL;
-            i -= 1;
+        if (strcmp(argv[i], "--force") == 0) {
+            force = 1;
+            g_no_claim = 1;
+        } else if (strcmp(argv[i], "--no-claim") == 0) {
+            g_no_claim = 1;
+        } else {
+            continue;
         }
+        int remaining = argc - i - 1;
+        memmove(&argv[i], &argv[i + 1], remaining * sizeof(char *));
+        argc -= 1;
+        argv[argc] = NULL;
+        i -= 1;
     }
 
     /* ---- Parse -F / --firmware option ---- */
@@ -455,27 +463,23 @@ int main(int argc, char **argv)
         return 2;
     }
 
-    /* --no-claim opens the device without claiming interface 0, so EP0 vendor
-     * commands run alongside a stream (per the firmware concurrency contract,
-     * ringof/rx888-firmware#170).  Gate which commands are allowed there using
-     * the per-command stream-safety class; --force opts in to the stream-unsafe
-     * ones (and the full debug console), accepting that they may stop/disrupt
-     * the stream.  --force only makes sense together with --no-claim. */
-    if (force && !g_no_claim) {
-        fprintf(stderr, "error: --force only applies to --no-claim\n");
-        return 2;
-    }
+    /* --no-claim (and --force, which implies it) opens the device without
+     * claiming interface 0, so EP0 vendor commands run alongside a stream (per
+     * the firmware concurrency contract, ringof/rx888-firmware#170).  Gate
+     * which commands are allowed using the per-command stream-safety class;
+     * --force opts in to the stream-unsafe ones (and the full debug console),
+     * accepting that they may stop/disrupt the stream. */
     if (g_no_claim) {
         if (spec->nc == NC_NO) {
-            fprintf(stderr, "error: '%s' cannot run under --no-claim; "
-                            "run it without --no-claim\n", cmd);
+            fprintf(stderr, "error: '%s' does not run under --no-claim/--force; "
+                            "run it on its own\n", cmd);
             return 2;
         }
         if (spec->nc == NC_FORCE && !force) {
             fprintf(stderr,
                 "error: '%s' is not stream-safe (per rx888-firmware#170) and can\n"
-                "       disrupt or stop a running stream. Re-run with\n"
-                "       '--no-claim --force' to do it anyway.\n", cmd);
+                "       disrupt or stop a running stream. Re-run with --force\n"
+                "       to do it anyway.\n", cmd);
             return 2;
         }
         if (spec->nc == NC_FORCE && force)

--- a/src/fx3_cmd/fx3_core.c
+++ b/src/fx3_cmd/fx3_core.c
@@ -227,9 +227,22 @@ int do_i2cr(libusb_device_handle *h, uint16_t addr, uint16_t reg, uint16_t len)
     uint8_t buf[64];
     if (len > sizeof(buf)) len = sizeof(buf);
 
+    /* Enable USB debug first so a firmware-side I2C failure is captured: the
+     * I2CRFX3 handler logs CyU3PI2cGetErrorCode (the granular NAK reason) via
+     * DebugPrint2USB, which only buffers when debug mode is on (#163). */
+    ctrl_read(h, TESTFX3, 1, 0, buf, 4);
+
     int r = ctrl_read(h, I2CRFX3, addr, reg, buf, len);
     if (r < 0) {
         printf("FAIL i2cr addr=0x%02X reg=0x%02X: %s\n", addr, reg, libusb_strerror(r));
+        /* Drain the firmware debug buffer — surfaces "I2CRD ... ec=N", where
+         * ec=0 NAK_BYTE_0 (address), 1 NAK_BYTE_1 (register), 8 NAK_DATA. */
+        uint8_t dbg[64];
+        for (int k = 0; k < 16; k++) {
+            int n = ctrl_read(h, READINFODEBUG, 0, 0, dbg, sizeof(dbg));
+            if (n > 1) printf("  [fw]%.*s\n", n - 1, (char *)dbg);
+            usleep(15000);
+        }
         return 1;
     }
     printf("PASS i2cr addr=0x%02X reg=0x%02X len=%d:", addr, reg, r);

--- a/tests/fx3_cmd_smoke.sh
+++ b/tests/fx3_cmd_smoke.sh
@@ -85,8 +85,8 @@ check_rc 2 "--no-claim raw rejected (needs --force)"        "$FX3" --no-claim ra
 check_rc 2 "--no-claim usbreset rejected (no-claim n/a)"    "$FX3" --no-claim usbreset
 check_rc 2 "--no-claim reload rejected (no-claim n/a)"      "$FX3" --no-claim reload
 check_rc 2 "--no-claim load rejected (no-claim n/a)"        "$FX3" --no-claim load
-# --force only applies with --no-claim.
-check_rc 2 "--force without --no-claim rejected" "$FX3" --force gpio 0x20
+# --force implies --no-claim, so it inherits the NC_NO rejection too.
+check_rc 2 "--force usbreset rejected (no-claim n/a)"       "$FX3" --force usbreset
 
 # Without hardware, a valid command with correct arity must fail cleanly at
 # device open (exit 1) — not segfault, not hang, not 0. (gpio needs an arg;
@@ -102,8 +102,10 @@ if [[ "${RX888_HW_PRESENT:-0}" != "1" ]]; then
     check_rc 1 "no-device --no-claim att"  "$FX3" --no-claim att 0
     check_rc 1 "no-device --no-claim vga"  "$FX3" --no-claim vga 0
     check_rc 1 "no-device --no-claim wdg_max" "$FX3" --no-claim wdg_max 0
-    # --force lets a stream-unsafe command past the gate; still fails at open.
-    check_rc 1 "no-device --no-claim --force gpio" "$FX3" --no-claim --force gpio 0x20
+    # --force lets a stream-unsafe command past the gate (and implies --no-claim,
+    # so it works on its own); still fails at open with no device.
+    check_rc 1 "no-device --force gpio (implies --no-claim)" "$FX3" --force gpio 0x20
+    check_rc 1 "no-device --no-claim --force gpio"           "$FX3" --no-claim --force gpio 0x20
 fi
 
 if [[ $failures -eq 0 ]]; then

--- a/tests/fx3_cmd_smoke.sh
+++ b/tests/fx3_cmd_smoke.sh
@@ -52,11 +52,13 @@ for c in load reload test gpio adc att vga wdg_max start stop \
         fail "usage missing $c"
     fi
 done
-if grep -q -- "--no-claim" "$tmp_help"; then
-    ok "usage lists --no-claim"
-else
-    fail "usage missing --no-claim"
-fi
+for flag in --no-claim --force; do
+    if grep -q -- "$flag" "$tmp_help"; then
+        ok "usage lists $flag"
+    else
+        fail "usage missing $flag"
+    fi
+done
 
 # No arguments prints usage and exits 2 (usage error).
 check_rc 2 "no-arg" "$FX3"
@@ -69,13 +71,22 @@ check_rc 2 "missing arg (gpio)"  "$FX3" gpio
 check_rc 2 "too few args (i2cr)" "$FX3" i2cr 0xC0 0
 check_rc 2 "extra arg (test)"    "$FX3" test extra
 
-# --no-claim is only allowed for read-only EP0 commands; a valid-arity
-# write/recovery command with --no-claim is rejected by the allowlist with
-# rc=2 (no device needed).
-check_rc 2 "--no-claim gpio rejected" "$FX3" --no-claim gpio 0x20
-for c in reset usbreset reload stats_shdn; do
-    check_rc 2 "--no-claim $c rejected" "$FX3" --no-claim "$c"
-done
+# --no-claim allows only the stream-safe EP0 commands (per rx888-firmware#170).
+# A stream-UNSAFE command under --no-claim without --force is rejected (rc=2),
+# and so is a non-coexistence command (load/usbreset/reload) — all before any
+# device access. (Valid arity, so the stream-safety gate is what fires.)
+check_rc 2 "--no-claim gpio rejected (needs --force)"       "$FX3" --no-claim gpio 0x20
+check_rc 2 "--no-claim adc rejected (needs --force)"        "$FX3" --no-claim adc 32000000
+check_rc 2 "--no-claim start rejected (needs --force)"      "$FX3" --no-claim start
+check_rc 2 "--no-claim stop rejected (needs --force)"       "$FX3" --no-claim stop
+check_rc 2 "--no-claim debug rejected (needs --force)"      "$FX3" --no-claim debug
+check_rc 2 "--no-claim stats_shdn rejected (needs --force)" "$FX3" --no-claim stats_shdn
+check_rc 2 "--no-claim raw rejected (needs --force)"        "$FX3" --no-claim raw 0xAA
+check_rc 2 "--no-claim usbreset rejected (no-claim n/a)"    "$FX3" --no-claim usbreset
+check_rc 2 "--no-claim reload rejected (no-claim n/a)"      "$FX3" --no-claim reload
+check_rc 2 "--no-claim load rejected (no-claim n/a)"        "$FX3" --no-claim load
+# --force only applies with --no-claim.
+check_rc 2 "--force without --no-claim rejected" "$FX3" --force gpio 0x20
 
 # Without hardware, a valid command with correct arity must fail cleanly at
 # device open (exit 1) — not segfault, not hang, not 0. (gpio needs an arg;
@@ -86,6 +97,13 @@ if [[ "${RX888_HW_PRESENT:-0}" != "1" ]]; then
     check_rc 1 "no-device gpio"            "$FX3" gpio 0x20
     check_rc 1 "no-device reset"           "$FX3" reset
     check_rc 1 "no-device --no-claim test" "$FX3" --no-claim test
+    # Stream-safe writes are now allowed under --no-claim: they pass the gate
+    # and fail at device open (rc=1), not at the gate (rc=2).
+    check_rc 1 "no-device --no-claim att"  "$FX3" --no-claim att 0
+    check_rc 1 "no-device --no-claim vga"  "$FX3" --no-claim vga 0
+    check_rc 1 "no-device --no-claim wdg_max" "$FX3" --no-claim wdg_max 0
+    # --force lets a stream-unsafe command past the gate; still fails at open.
+    check_rc 1 "no-device --no-claim --force gpio" "$FX3" --no-claim --force gpio 0x20
 fi
 
 if [[ $failures -eq 0 ]]; then

--- a/tests/hw_fx3_cmd.sh
+++ b/tests/hw_fx3_cmd.sh
@@ -179,8 +179,23 @@ else
     fail "stream stalled across --no-claim stack_check ($dma_sc1 -> $dma_sc2) (re #27)"
 fi
 
-# --- 5. --no-claim allowlist rejects a write command -------------------------
-check 2 "--no-claim gpio rejected" "$FX3" --no-claim gpio 0x20
+# att/vga are stream-SAFE per rx888-firmware#170 (SETARGFX3 live tuning): they
+# must succeed under --no-claim during a stream and not disrupt it.
+dma_t1="$(stat_field dma --no-claim)"
+check 0 "--no-claim att during stream" "$FX3" --no-claim att 0
+check 0 "--no-claim vga during stream" "$FX3" --no-claim vga 0
+sleep 1
+dma_t2="$(stat_field dma --no-claim)"
+if [[ -n "$dma_t1" && -n "$dma_t2" && "$dma_t2" -gt "$dma_t1" ]]; then
+    ok "--no-claim att/vga non-disruptive: dma $dma_t1 -> $dma_t2"
+else
+    fail "stream stalled across --no-claim att/vga ($dma_t1 -> $dma_t2)"
+fi
+
+# --- 5. --no-claim gating: stream-unsafe rejected without --force ------------
+# (We don't run --force write commands here — they'd intentionally disrupt the
+# stream; the smoke test covers that --force passes the gate.)
+check 2 "--no-claim gpio rejected (needs --force)" "$FX3" --no-claim gpio 0x20
 
 # --- 6. device healthy again once the streamer detaches ----------------------
 cleanup; STREAM_PID=""

--- a/tests/hw_fx3_cmd.sh
+++ b/tests/hw_fx3_cmd.sh
@@ -11,12 +11,14 @@
 #   3. exclusive-access guard          a normal fx3_cmd command is refused
 #                                      with "Resource busy" (exit 1) while
 #                                      rx888_stream holds interface 0
-#   4. --no-claim concurrency          read-only commands succeed alongside the
-#                                      stream, GETSTATS dma_count advances while
+#   4. --no-claim concurrency          stream-safe commands succeed alongside
+#                                      the stream (incl. live att/vga tuning),
+#                                      GETSTATS dma_count advances while
 #                                      boot_count stays put, and --no-claim
 #                                      stack_check (the debug/EP0 channel) does
 #                                      not stall the stream (probes issue #27)
-#   5. --no-claim allowlist            a write command is rejected (exit 2)
+#   5. --no-claim gating               a stream-unsafe command (gpio) is
+#                                      rejected without --force (exit 2)
 #   6. post-stream health              claim works again once the streamer
 #                                      detaches
 #
@@ -164,7 +166,7 @@ else
     fail "boot_count changed ($boot1 -> $boot2): device reset under the stream"
 fi
 
-# --no-claim stack_check is the one allowlisted no-claim command that drives the
+# --no-claim stack_check is the one stream-safe no-claim command that drives the
 # READINFODEBUG debug channel (EP0).  Running it mid-stream probes issue #27:
 # does the debug channel disturb an active stream?  We do not assert
 # stack_check's own result (its console parse may legitimately fail on some


### PR DESCRIPTION
Closes #28.

## Summary

Lets `fx3_cmd` do more **while a stream is running**, grounded in the firmware
concurrency contract documented in
[`ringof/rx888-firmware#170`](https://github.com/ringof/rx888-firmware/issues/170):
EP0 vendor requests are serviced on a **separate firmware thread** from the
GPIF→DMA streaming path, with a per-command safety map. No firmware changes are
needed — this is entirely host-side.

Two changes:

1. **Reclassify `--no-claim` as "stream-safe", not "read-only", and widen it.**
   Each command is tagged with a stream-safety class. `--no-claim` now allows
   the stream-safe set, which **adds `att`/`vga`/`wdg_max`** (`SETARGFX3` — live
   gain/attenuator tuning) to the previous `test`/`stats`/`stats_pll`/
   `stack_check`. (Also retires the imprecise "read-only" wording, addressing a
   prior review note that `stack_check` wasn't really read-only.)

2. **Add `--force`, which implies `--no-claim`.** It permits the stream-**unsafe**
   commands — `gpio`, `adc`, `start`, `stop`, `reset`, `stats_shdn`, `i2c*`,
   `raw` — and the **full interactive `debug` console** to run during a stream,
   with an on-entry warning. Everything is EP0 (no interface claim either way),
   so the firmware won't crash; the accepted consequence is that these
   glitch/stop/reset the device out from under the streamer.

   `--force` implies `--no-claim` because you never claim the interface to
   disrupt a stream — the disruption is via EP0 vendor commands regardless — so
   requiring both flags was pointless. One flag per intent:

   ```sh
   fx3_cmd --no-claim stats      # stream-safe: query during a stream
   fx3_cmd --no-claim att 20     # stream-safe: live attenuator tuning
   fx3_cmd --no-claim gpio 0x20  # error (2): not stream-safe; re-run with --force
   fx3_cmd --force gpio 0x20     # runs it; warns it may disrupt the stream
   fx3_cmd --force debug         # full console during a stream (knowingly disruptive)
   ```

## Stream-safety map (from rx888-firmware#170)

| Class | Commands | Vendor requests |
|---|---|---|
| **safe** (`--no-claim`) | `test`, `stats`, `stats_pll`, `stack_check`, `att`, `vga`, `wdg_max` | `TESTFX3`, `GETSTATS`, `READINFODEBUG`, `SETARGFX3` |
| **unsafe** (`--force`) | `gpio`, `adc`, `start`, `stop`, `reset`, `stats_shdn`, `i2cr`, `i2cw`, `raw`, `debug` | `GPIOFX3`, `STARTADC`, `STARTFX3`, `STOPFX3`, `RESETFX3`, … |
| **n/a** under `--no-claim`/`--force` | `load`, `usbreset`, `reload` | — |

## Tests

- `tests/fx3_cmd_smoke.sh` (no hardware): stream-safe writes pass the gate;
  stream-unsafe need `--force`; `--force` alone works (implies `--no-claim`);
  `load`/`usbreset`/`reload` rejected under `--no-claim`/`--force`.
  shellcheck-clean.
- `tests/hw_fx3_cmd.sh`: asserts `--no-claim att`/`vga` succeed during a stream
  and keep `dma_count` advancing (non-disruptive), and that `gpio` is rejected
  without `--force`. (Doesn't run `--force` writes — they'd intentionally
  disrupt the test's own stream.)
- `make check` + `make check-asan` pass; `make all` clean (no warnings).

## Also

- `.gitignore`: anchor the compiled-binary rules to the repo root — the bare
  `fx3_cmd` rule also matched the `src/fx3_cmd/` source dir, so new source files
  there were ignored by default.

## Relationship to #27

#27 (observe-only *restricted* debug console) remains its own follow-up; this PR
delivers the full/`--force` console and the `--no-claim` reclassification they
share. A restricted console can later land under #27 selecting the safe subset.

https://claude.ai/code/session_01RZ5bR3gn5DQEfvJDqjrwVZ