### PR TITLE
fx3_cmd: port do_i2cr I2C-NAK debug-drain from rx888-firmware#163 (restore convergence)

### DIFF
--- a/doc/fx3_cmd.md
+++ b/doc/fx3_cmd.md
@@ -43,7 +43,7 @@ Built at the repo root next to `rx888_stream` (and installed into the same
 | `vga <0-255>` | `SETARGFX3`/`AD8370_VGA` | AD8370 VGA gain code |
 | `wdg_max <0-255>` | `SETARGFX3`/`WDG_MAX_RECOV` | Watchdog max recovery count (0 = unlimited) |
 | `start` / `stop` | `STARTFX3` / `STOPFX3` | Start / stop the GPIF streaming engine |
-| `i2cr <addr> <reg> <len>` | `I2CRFX3` | I2C read (hex) |
+| `i2cr <addr> <reg> <len>` | `I2CRFX3` | I2C read (hex). On failure, enables firmware debug and drains the I2C NAK reason (`ec=N`). |
 | `i2cw <addr> <reg> <byte>...` | `I2CWFX3` | I2C write (hex) |
 | `stats` | `GETSTATS` | Dump the firmware diagnostic counters |
 | `stats_pll` | `GETSTATS` | Verify the Si5351 PLL is locked |

--- a/src/fx3_cmd/fx3_core.c
+++ b/src/fx3_cmd/fx3_core.c
@@ -227,9 +227,22 @@ int do_i2cr(libusb_device_handle *h, uint16_t addr, uint16_t reg, uint16_t len)
     uint8_t buf[64];
     if (len > sizeof(buf)) len = sizeof(buf);
 
+    /* Enable USB debug first so a firmware-side I2C failure is captured: the
+     * I2CRFX3 handler logs CyU3PI2cGetErrorCode (the granular NAK reason) via
+     * DebugPrint2USB, which only buffers when debug mode is on (#163). */
+    ctrl_read(h, TESTFX3, 1, 0, buf, 4);
+
     int r = ctrl_read(h, I2CRFX3, addr, reg, buf, len);
     if (r < 0) {
         printf("FAIL i2cr addr=0x%02X reg=0x%02X: %s\n", addr, reg, libusb_strerror(r));
+        /* Drain the firmware debug buffer — surfaces "I2CRD ... ec=N", where
+         * ec=0 NAK_BYTE_0 (address), 1 NAK_BYTE_1 (register), 8 NAK_DATA. */
+        uint8_t dbg[64];
+        for (int k = 0; k < 16; k++) {
+            int n = ctrl_read(h, READINFODEBUG, 0, 0, dbg, sizeof(dbg));
+            if (n > 1) printf("  [fw]%.*s\n", n - 1, (char *)dbg);
+            usleep(15000);
+        }
         return 1;
     }
     printf("PASS i2cr addr=0x%02X reg=0x%02X len=%d:", addr, reg, r);


### PR DESCRIPTION
## Summary

Ports the `do_i2cr` I2C-NAK debug-drain from
[`ringof/rx888-firmware#163`](https://github.com/ringof/rx888-firmware/issues/163)
into this repo's **shared FX3 core** (`src/fx3_cmd/fx3_core.c`).

`do_i2cr` was improved in the firmware repo (#163) to surface the firmware-side
I2C NAK reason — but that edit landed in `rx888-firmware`'s `tests/fx3_cmd.c`
back when that was the only copy of the function. `do_i2cr` now lives here in the
shared core, which the firmware harness will consume via submodule, so the two
had **diverged** (this repo still had the plain version). Hand-carrying the
change restores convergence.

This is a **one-time transitional cost** of cutting over to the shared core
mid-stream: once `rx888-firmware`'s Phase-3 PR (#162) lands and the
"core edits go upstream-first" rule holds, this manual porting goes away.

## What changes

On the **failure path**, `i2cr` now enables firmware debug mode and drains the
debug buffer to print the granular NAK reason:

```
FAIL i2cr addr=0xFE reg=0x00: ...
  [fw]I2CRD ... ec=0      # ec=0 NAK address, 1 NAK register, 8 NAK data
```

Faithful port — kept byte-for-byte with the firmware version so it doesn't
re-diverge; the only intentional difference is the signature stays non-`static`
(it was file-local in the firmware's `fx3_cmd.c`; here it's exported from the
core).

## Notes / behaviour

- **Side effect:** `i2cr` now issues `TESTFX3 wValue=1` (enables firmware debug
  mode, same mechanism as `stack_check`) at the start of every call, so it is no
  longer a pure passive read. It therefore stays **out of the stream-safe
  `--no-claim` set** — which it already is on `main`, and remains so under PR #29's
  `NC_FORCE` classification.
- **Latency:** the ~240 ms drain (16 × 15 ms) runs **only on the failure path**;
  the success path is unchanged.
- **No new includes** — `fx3_core.c` already has `<unistd.h>` (`usleep`), and
  `TESTFX3`/`I2CRFX3`/`READINFODEBUG` come from `include/rx888.h`.
- **Firmware-version dependent:** against firmware predating #163 the drain reads
  an empty buffer (harmless no-op); it lights up once a firmware carrying #163 is
  pinned in `firmware/VERSION`.

## Validation

- No hardware: `make` / `make check` compile clean (the change is logic-local to
  the failure branch).
- Hardware (manual): `fx3_cmd i2cr 0xC0 0x00 1` on a healthy Si5351 still prints
  `PASS …`; a bad address (`fx3_cmd i2cr 0xFE 0x00 1`) now also prints `[fw]…ec=N`
  lines (on a firmware with #163).

## Cross-repo follow-up

Independent of PR #29 (that touches the gating in `fx3_cmd.c`; this touches
`do_i2cr` in `fx3_core.c` — no overlap). Once this merges, `rx888-firmware` bumps
its `tests/rx888_tools` submodule pin past the merge commit so its harness picks
up the restored `do_i2cr`; I'll flag the merge SHA for that pin bump.

Not included: #163 also added a new `do_i2c_sweep` diagnostic in the firmware
harness. It's additive (not a convergence blocker) and the source wasn't part of
this handoff — can port it separately if we want it in the product.

https://claude.ai/code/session_01RZ5bR3gn5DQEfvJDqjrwVZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZ5bR3gn5DQEfvJDqjrwVZ)_